### PR TITLE
Add device ID configuration and validate IoT payloads

### DIFF
--- a/Backend-JS/iot-service/README.md
+++ b/Backend-JS/iot-service/README.md
@@ -1,0 +1,47 @@
+# Krishi Mantra IoT Service (Go)
+
+This service runs multiple IoT workloads (device publisher, parser, soil consumer, weather consumer) based on the `APP_TYPE` value supplied via deployment configuration/Helm chart.
+
+## App Types
+
+| APP_TYPE | Role |
+| --- | --- |
+| `device` | Publishes simulated sensor payloads every `DEVICE_INTERVAL_SECONDS` to MQTT. |
+| `parser` | Subscribes to raw MQTT messages, splits into soil and weather payloads, and publishes them to the respective topics. |
+| `soil` | Subscribes to the soil topic, validates readings, and stores them in ClickHouse. |
+| `weather` | Subscribes to the weather topic, validates readings, and stores them in ClickHouse. |
+
+## Environment Variables
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `APP_TYPE` | (required) | `device`, `parser`, `soil`, or `weather`. |
+| `DEVICE_INTERVAL_SECONDS` | `10` | Interval for device payloads. |
+| `DEVICE_ID` | `krishi-device-001` | Device identifier used by the simulator. |
+| `MQTT_BROKER_URL` | `tcp://localhost:1883` | MQTT broker URL (Mosca or compatible). |
+| `MQTT_USERNAME` | | MQTT username. |
+| `MQTT_PASSWORD` | | MQTT password. |
+| `MQTT_CLIENT_ID` | `krishi-iot` | MQTT client ID. |
+| `MQTT_RAW_TOPIC` | `krishi/iot/raw` | Raw payload topic. |
+| `MQTT_SOIL_TOPIC` | `krishi/iot/soil` | Soil payload topic. |
+| `MQTT_WEATHER_TOPIC` | `krishi/iot/weather` | Weather payload topic. |
+| `CLICKHOUSE_ADDR` | `localhost:9000` | ClickHouse host:port. |
+| `CLICKHOUSE_DATABASE` | `krishi_iot` | Database name. |
+| `CLICKHOUSE_USERNAME` | `default` | ClickHouse user. |
+| `CLICKHOUSE_PASSWORD` | | ClickHouse password. |
+
+## Local Run
+
+```bash
+cd Backend-JS/iot-service
+export APP_TYPE=parser
+export MQTT_BROKER_URL=tcp://localhost:1883
+export CLICKHOUSE_ADDR=localhost:9000
+
+go run ./cmd/iot-service
+```
+
+## Notes
+
+- Mosca can be used as the MQTT broker.
+- The soil and weather consumers create ClickHouse tables automatically.

--- a/Backend-JS/iot-service/cmd/iot-service/main.go
+++ b/Backend-JS/iot-service/cmd/iot-service/main.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+
+	"krishi-mantra/iot-service/internal/config"
+	"krishi-mantra/iot-service/internal/consumers"
+)
+
+func main() {
+	cfg, err := config.Load()
+	if err != nil {
+		log.Fatalf("failed to load config: %v", err)
+	}
+
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer cancel()
+
+	appType := strings.ToLower(strings.TrimSpace(cfg.AppType))
+	log.Printf("starting iot-service with app type: %s", appType)
+
+	var runErr error
+	switch appType {
+	case "device":
+		runErr = consumers.RunDevice(ctx, cfg)
+	case "parser":
+		runErr = consumers.RunParser(ctx, cfg)
+	case "soil":
+		runErr = consumers.RunSoil(ctx, cfg)
+	case "weather":
+		runErr = consumers.RunWeather(ctx, cfg)
+	default:
+		log.Fatalf("unknown APP_TYPE: %s", cfg.AppType)
+	}
+
+	if runErr != nil {
+		log.Fatalf("service stopped with error: %v", runErr)
+	}
+}

--- a/Backend-JS/iot-service/go.mod
+++ b/Backend-JS/iot-service/go.mod
@@ -1,0 +1,9 @@
+module krishi-mantra/iot-service
+
+go 1.21
+
+require (
+    github.com/ClickHouse/clickhouse-go/v2 v2.18.0
+    github.com/eclipse/paho.mqtt.golang v1.4.3
+)
+

--- a/Backend-JS/iot-service/internal/config/config.go
+++ b/Backend-JS/iot-service/internal/config/config.go
@@ -1,0 +1,79 @@
+package config
+
+import (
+	"errors"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type Config struct {
+	AppType        string
+	MQTT           MQTTConfig
+	ClickHouse     ClickHouseConfig
+	DeviceInterval time.Duration
+	DeviceID       string
+}
+
+type MQTTConfig struct {
+	BrokerURL    string
+	Username     string
+	Password     string
+	ClientID     string
+	RawTopic     string
+	SoilTopic    string
+	WeatherTopic string
+}
+
+type ClickHouseConfig struct {
+	Addr     string
+	Database string
+	Username string
+	Password string
+}
+
+func Load() (Config, error) {
+	appType := strings.TrimSpace(os.Getenv("APP_TYPE"))
+	if appType == "" {
+		return Config{}, errors.New("APP_TYPE is required")
+	}
+
+	intervalSeconds := 10
+	if value := strings.TrimSpace(os.Getenv("DEVICE_INTERVAL_SECONDS")); value != "" {
+		parsed, err := strconv.Atoi(value)
+		if err == nil && parsed > 0 {
+			intervalSeconds = parsed
+		}
+	}
+
+	cfg := Config{
+		AppType: appType,
+		MQTT: MQTTConfig{
+			BrokerURL:    getEnv("MQTT_BROKER_URL", "tcp://localhost:1883"),
+			Username:     os.Getenv("MQTT_USERNAME"),
+			Password:     os.Getenv("MQTT_PASSWORD"),
+			ClientID:     getEnv("MQTT_CLIENT_ID", "krishi-iot"),
+			RawTopic:     getEnv("MQTT_RAW_TOPIC", "krishi/iot/raw"),
+			SoilTopic:    getEnv("MQTT_SOIL_TOPIC", "krishi/iot/soil"),
+			WeatherTopic: getEnv("MQTT_WEATHER_TOPIC", "krishi/iot/weather"),
+		},
+		ClickHouse: ClickHouseConfig{
+			Addr:     getEnv("CLICKHOUSE_ADDR", "localhost:9000"),
+			Database: getEnv("CLICKHOUSE_DATABASE", "krishi_iot"),
+			Username: getEnv("CLICKHOUSE_USERNAME", "default"),
+			Password: os.Getenv("CLICKHOUSE_PASSWORD"),
+		},
+		DeviceInterval: time.Duration(intervalSeconds) * time.Second,
+		DeviceID:       getEnv("DEVICE_ID", "krishi-device-001"),
+	}
+
+	return cfg, nil
+}
+
+func getEnv(key, fallback string) string {
+	if value := strings.TrimSpace(os.Getenv(key)); value != "" {
+		return value
+	}
+	return fallback
+}

--- a/Backend-JS/iot-service/internal/consumers/device.go
+++ b/Backend-JS/iot-service/internal/consumers/device.go
@@ -1,0 +1,67 @@
+package consumers
+
+import (
+	"context"
+	"encoding/json"
+	"log"
+	"math/rand"
+	"time"
+
+	"krishi-mantra/iot-service/internal/config"
+	"krishi-mantra/iot-service/internal/models"
+	mqttclient "krishi-mantra/iot-service/internal/mqtt"
+)
+
+func RunDevice(ctx context.Context, cfg config.Config) error {
+	client, err := mqttclient.New(cfg.MQTT)
+	if err != nil {
+		return err
+	}
+	defer client.Disconnect(250)
+
+	ticker := time.NewTicker(cfg.DeviceInterval)
+	defer ticker.Stop()
+
+	log.Printf("starting device publisher with interval %s", cfg.DeviceInterval)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case tickTime := <-ticker.C:
+			payload := models.RawPayload{
+				DeviceID:  cfg.DeviceID,
+				Timestamp: tickTime.UTC(),
+				Soil: models.SoilData{
+					Moisture:    randRange(rng, 25, 65),
+					Temperature: randRange(rng, 18, 32),
+					PH:          randRange(rng, 5.5, 7.5),
+					EC:          randRange(rng, 0.5, 2.0),
+				},
+				Weather: models.WeatherData{
+					Temperature: randRange(rng, 20, 38),
+					Humidity:    randRange(rng, 40, 85),
+					Rainfall:    randRange(rng, 0, 12),
+					WindSpeed:   randRange(rng, 0, 15),
+					Pressure:    randRange(rng, 980, 1020),
+				},
+			}
+
+			data, err := json.Marshal(payload)
+			if err != nil {
+				log.Printf("failed to marshal payload: %v", err)
+				continue
+			}
+			if err := client.Publish(cfg.MQTT.RawTopic, 1, false, data); err != nil {
+				log.Printf("failed to publish payload: %v", err)
+			} else {
+				log.Printf("published device payload to %s", cfg.MQTT.RawTopic)
+			}
+		}
+	}
+}
+
+func randRange(rng *rand.Rand, min, max float64) float64 {
+	return min + rng.Float64()*(max-min)
+}

--- a/Backend-JS/iot-service/internal/consumers/parser.go
+++ b/Backend-JS/iot-service/internal/consumers/parser.go
@@ -1,0 +1,63 @@
+package consumers
+
+import (
+	"context"
+	"encoding/json"
+	"log"
+
+	"github.com/eclipse/paho.mqtt.golang"
+
+	"krishi-mantra/iot-service/internal/config"
+	"krishi-mantra/iot-service/internal/models"
+	mqttclient "krishi-mantra/iot-service/internal/mqtt"
+)
+
+func RunParser(ctx context.Context, cfg config.Config) error {
+	client, err := mqttclient.New(cfg.MQTT)
+	if err != nil {
+		return err
+	}
+	defer client.Disconnect(250)
+
+	handler := func(_ mqtt.Client, msg mqtt.Message) {
+		var payload models.RawPayload
+		if err := json.Unmarshal(msg.Payload(), &payload); err != nil {
+			log.Printf("failed to parse raw payload: %v", err)
+			return
+		}
+
+		soilPayload := models.SoilPayload{
+			DeviceID:  payload.DeviceID,
+			Timestamp: payload.Timestamp,
+			Soil:      payload.Soil,
+		}
+		weatherPayload := models.WeatherPayload{
+			DeviceID:  payload.DeviceID,
+			Timestamp: payload.Timestamp,
+			Weather:   payload.Weather,
+		}
+
+		if err := publishPayload(client, cfg.MQTT.SoilTopic, soilPayload); err != nil {
+			log.Printf("failed to publish soil payload: %v", err)
+		}
+		if err := publishPayload(client, cfg.MQTT.WeatherTopic, weatherPayload); err != nil {
+			log.Printf("failed to publish weather payload: %v", err)
+		}
+	}
+
+	if err := client.Subscribe(cfg.MQTT.RawTopic, 1, handler); err != nil {
+		return err
+	}
+	log.Printf("parser subscribed to %s", cfg.MQTT.RawTopic)
+
+	<-ctx.Done()
+	return nil
+}
+
+func publishPayload(client *mqttclient.Client, topic string, payload any) error {
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	return client.Publish(topic, 1, false, data)
+}

--- a/Backend-JS/iot-service/internal/consumers/soil.go
+++ b/Backend-JS/iot-service/internal/consumers/soil.go
@@ -1,0 +1,53 @@
+package consumers
+
+import (
+	"context"
+	"encoding/json"
+	"log"
+
+	"github.com/eclipse/paho.mqtt.golang"
+
+	"krishi-mantra/iot-service/internal/config"
+	"krishi-mantra/iot-service/internal/models"
+	mqttclient "krishi-mantra/iot-service/internal/mqtt"
+	"krishi-mantra/iot-service/internal/storage"
+)
+
+func RunSoil(ctx context.Context, cfg config.Config) error {
+	store, err := storage.NewClickHouse(cfg.ClickHouse)
+	if err != nil {
+		return err
+	}
+	if err := store.Init(ctx); err != nil {
+		return err
+	}
+
+	client, err := mqttclient.New(cfg.MQTT)
+	if err != nil {
+		return err
+	}
+	defer client.Disconnect(250)
+
+	handler := func(_ mqtt.Client, msg mqtt.Message) {
+		var payload models.SoilPayload
+		if err := json.Unmarshal(msg.Payload(), &payload); err != nil {
+			log.Printf("failed to parse soil payload: %v", err)
+			return
+		}
+		if err := validateSoil(payload); err != nil {
+			log.Printf("soil payload validation failed: %v", err)
+			return
+		}
+		if err := store.InsertSoil(ctx, payload); err != nil {
+			log.Printf("failed to insert soil payload: %v", err)
+		}
+	}
+
+	if err := client.Subscribe(cfg.MQTT.SoilTopic, 1, handler); err != nil {
+		return err
+	}
+	log.Printf("soil consumer subscribed to %s", cfg.MQTT.SoilTopic)
+
+	<-ctx.Done()
+	return nil
+}

--- a/Backend-JS/iot-service/internal/consumers/validation.go
+++ b/Backend-JS/iot-service/internal/consumers/validation.go
@@ -1,0 +1,57 @@
+package consumers
+
+import (
+	"fmt"
+	"strings"
+
+	"krishi-mantra/iot-service/internal/models"
+)
+
+func validateSoil(payload models.SoilPayload) error {
+	if strings.TrimSpace(payload.DeviceID) == "" {
+		return fmt.Errorf("device_id is required")
+	}
+	if payload.Timestamp.IsZero() {
+		return fmt.Errorf("timestamp is required")
+	}
+	soil := payload.Soil
+	if soil.Moisture < 0 || soil.Moisture > 100 {
+		return fmt.Errorf("moisture out of range: %.2f", soil.Moisture)
+	}
+	if soil.Temperature < -10 || soil.Temperature > 80 {
+		return fmt.Errorf("soil temperature out of range: %.2f", soil.Temperature)
+	}
+	if soil.PH < 3 || soil.PH > 10 {
+		return fmt.Errorf("soil pH out of range: %.2f", soil.PH)
+	}
+	if soil.EC < 0 || soil.EC > 20 {
+		return fmt.Errorf("soil EC out of range: %.2f", soil.EC)
+	}
+	return nil
+}
+
+func validateWeather(payload models.WeatherPayload) error {
+	if strings.TrimSpace(payload.DeviceID) == "" {
+		return fmt.Errorf("device_id is required")
+	}
+	if payload.Timestamp.IsZero() {
+		return fmt.Errorf("timestamp is required")
+	}
+	weather := payload.Weather
+	if weather.Temperature < -40 || weather.Temperature > 80 {
+		return fmt.Errorf("temperature out of range: %.2f", weather.Temperature)
+	}
+	if weather.Humidity < 0 || weather.Humidity > 100 {
+		return fmt.Errorf("humidity out of range: %.2f", weather.Humidity)
+	}
+	if weather.Rainfall < 0 || weather.Rainfall > 500 {
+		return fmt.Errorf("rainfall out of range: %.2f", weather.Rainfall)
+	}
+	if weather.WindSpeed < 0 || weather.WindSpeed > 200 {
+		return fmt.Errorf("wind speed out of range: %.2f", weather.WindSpeed)
+	}
+	if weather.Pressure < 800 || weather.Pressure > 1200 {
+		return fmt.Errorf("pressure out of range: %.2f", weather.Pressure)
+	}
+	return nil
+}

--- a/Backend-JS/iot-service/internal/consumers/weather.go
+++ b/Backend-JS/iot-service/internal/consumers/weather.go
@@ -1,0 +1,53 @@
+package consumers
+
+import (
+	"context"
+	"encoding/json"
+	"log"
+
+	"github.com/eclipse/paho.mqtt.golang"
+
+	"krishi-mantra/iot-service/internal/config"
+	"krishi-mantra/iot-service/internal/models"
+	mqttclient "krishi-mantra/iot-service/internal/mqtt"
+	"krishi-mantra/iot-service/internal/storage"
+)
+
+func RunWeather(ctx context.Context, cfg config.Config) error {
+	store, err := storage.NewClickHouse(cfg.ClickHouse)
+	if err != nil {
+		return err
+	}
+	if err := store.Init(ctx); err != nil {
+		return err
+	}
+
+	client, err := mqttclient.New(cfg.MQTT)
+	if err != nil {
+		return err
+	}
+	defer client.Disconnect(250)
+
+	handler := func(_ mqtt.Client, msg mqtt.Message) {
+		var payload models.WeatherPayload
+		if err := json.Unmarshal(msg.Payload(), &payload); err != nil {
+			log.Printf("failed to parse weather payload: %v", err)
+			return
+		}
+		if err := validateWeather(payload); err != nil {
+			log.Printf("weather payload validation failed: %v", err)
+			return
+		}
+		if err := store.InsertWeather(ctx, payload); err != nil {
+			log.Printf("failed to insert weather payload: %v", err)
+		}
+	}
+
+	if err := client.Subscribe(cfg.MQTT.WeatherTopic, 1, handler); err != nil {
+		return err
+	}
+	log.Printf("weather consumer subscribed to %s", cfg.MQTT.WeatherTopic)
+
+	<-ctx.Done()
+	return nil
+}

--- a/Backend-JS/iot-service/internal/models/payload.go
+++ b/Backend-JS/iot-service/internal/models/payload.go
@@ -1,0 +1,37 @@
+package models
+
+import "time"
+
+type SoilData struct {
+	Moisture    float64 `json:"moisture"`
+	Temperature float64 `json:"temperature"`
+	PH          float64 `json:"ph"`
+	EC          float64 `json:"ec"`
+}
+
+type WeatherData struct {
+	Temperature float64 `json:"temperature"`
+	Humidity    float64 `json:"humidity"`
+	Rainfall    float64 `json:"rainfall"`
+	WindSpeed   float64 `json:"wind_speed"`
+	Pressure    float64 `json:"pressure"`
+}
+
+type RawPayload struct {
+	DeviceID  string      `json:"device_id"`
+	Timestamp time.Time   `json:"timestamp"`
+	Soil      SoilData    `json:"soil"`
+	Weather   WeatherData `json:"weather"`
+}
+
+type SoilPayload struct {
+	DeviceID  string    `json:"device_id"`
+	Timestamp time.Time `json:"timestamp"`
+	Soil      SoilData  `json:"soil"`
+}
+
+type WeatherPayload struct {
+	DeviceID  string      `json:"device_id"`
+	Timestamp time.Time   `json:"timestamp"`
+	Weather   WeatherData `json:"weather"`
+}

--- a/Backend-JS/iot-service/internal/mqtt/client.go
+++ b/Backend-JS/iot-service/internal/mqtt/client.go
@@ -1,0 +1,72 @@
+package mqtt
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/eclipse/paho.mqtt.golang"
+
+	"krishi-mantra/iot-service/internal/config"
+)
+
+type Client struct {
+	client mqtt.Client
+}
+
+func New(cfg config.MQTTConfig) (*Client, error) {
+	if cfg.BrokerURL == "" {
+		return nil, errors.New("MQTT_BROKER_URL is required")
+	}
+	clientID := cfg.ClientID
+	if clientID == "" {
+		clientID = fmt.Sprintf("krishi-iot-%d", time.Now().UnixNano())
+	}
+
+	options := mqtt.NewClientOptions()
+	options.AddBroker(cfg.BrokerURL)
+	options.SetClientID(clientID)
+	if cfg.Username != "" {
+		options.SetUsername(cfg.Username)
+	}
+	if cfg.Password != "" {
+		options.SetPassword(cfg.Password)
+	}
+	options.SetAutoReconnect(true)
+	options.SetConnectRetry(true)
+	options.SetConnectRetryInterval(5 * time.Second)
+	options.OnConnect = func(c mqtt.Client) {
+		log.Printf("connected to MQTT broker %s", cfg.BrokerURL)
+	}
+	options.OnConnectionLost = func(c mqtt.Client, err error) {
+		log.Printf("MQTT connection lost: %v", err)
+	}
+
+	client := mqtt.NewClient(options)
+	token := client.Connect()
+	if !token.WaitTimeout(10 * time.Second) {
+		return nil, errors.New("MQTT connection timeout")
+	}
+	if err := token.Error(); err != nil {
+		return nil, err
+	}
+
+	return &Client{client: client}, nil
+}
+
+func (c *Client) Publish(topic string, qos byte, retained bool, payload []byte) error {
+	token := c.client.Publish(topic, qos, retained, payload)
+	token.Wait()
+	return token.Error()
+}
+
+func (c *Client) Subscribe(topic string, qos byte, handler mqtt.MessageHandler) error {
+	token := c.client.Subscribe(topic, qos, handler)
+	token.Wait()
+	return token.Error()
+}
+
+func (c *Client) Disconnect(quiesce uint) {
+	c.client.Disconnect(quiesce)
+}

--- a/Backend-JS/iot-service/internal/storage/clickhouse.go
+++ b/Backend-JS/iot-service/internal/storage/clickhouse.go
@@ -1,0 +1,108 @@
+package storage
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ClickHouse/clickhouse-go/v2"
+
+	"krishi-mantra/iot-service/internal/config"
+	"krishi-mantra/iot-service/internal/models"
+)
+
+type ClickHouseStore struct {
+	conn     clickhouse.Conn
+	database string
+}
+
+func NewClickHouse(cfg config.ClickHouseConfig) (*ClickHouseStore, error) {
+	conn, err := clickhouse.Open(&clickhouse.Options{
+		Addr: []string{cfg.Addr},
+		Auth: clickhouse.Auth{
+			Database: cfg.Database,
+			Username: cfg.Username,
+			Password: cfg.Password,
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &ClickHouseStore{conn: conn, database: cfg.Database}, nil
+}
+
+func (s *ClickHouseStore) Init(ctx context.Context) error {
+	if err := s.conn.Exec(ctx, "CREATE DATABASE IF NOT EXISTS "+escapeIdent(s.database)); err != nil {
+		return err
+	}
+
+	if err := s.conn.Exec(ctx, fmt.Sprintf(soilTableDDLTemplate, escapeIdent(s.database))); err != nil {
+		return err
+	}
+	if err := s.conn.Exec(ctx, fmt.Sprintf(weatherTableDDLTemplate, escapeIdent(s.database))); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s *ClickHouseStore) InsertSoil(ctx context.Context, payload models.SoilPayload) error {
+	return s.conn.Exec(
+		ctx,
+		fmt.Sprintf(`INSERT INTO %s.soil_readings (device_id, timestamp, moisture, temperature, ph, ec)
+         VALUES (?, ?, ?, ?, ?, ?)`,
+			escapeIdent(s.database),
+		),
+		payload.DeviceID,
+		payload.Timestamp,
+		payload.Soil.Moisture,
+		payload.Soil.Temperature,
+		payload.Soil.PH,
+		payload.Soil.EC,
+	)
+}
+
+func (s *ClickHouseStore) InsertWeather(ctx context.Context, payload models.WeatherPayload) error {
+	return s.conn.Exec(
+		ctx,
+		fmt.Sprintf(`INSERT INTO %s.weather_readings (device_id, timestamp, temperature, humidity, rainfall, wind_speed, pressure)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`,
+			escapeIdent(s.database),
+		),
+		payload.DeviceID,
+		payload.Timestamp,
+		payload.Weather.Temperature,
+		payload.Weather.Humidity,
+		payload.Weather.Rainfall,
+		payload.Weather.WindSpeed,
+		payload.Weather.Pressure,
+	)
+}
+
+func escapeIdent(ident string) string {
+	return fmt.Sprintf("`%s`", ident)
+}
+
+const soilTableDDLTemplate = `
+CREATE TABLE IF NOT EXISTS %s.soil_readings (
+    device_id String,
+    timestamp DateTime,
+    moisture Float32,
+    temperature Float32,
+    ph Float32,
+    ec Float32
+) ENGINE = MergeTree()
+ORDER BY (device_id, timestamp)
+`
+
+const weatherTableDDLTemplate = `
+CREATE TABLE IF NOT EXISTS %s.weather_readings (
+    device_id String,
+    timestamp DateTime,
+    temperature Float32,
+    humidity Float32,
+    rainfall Float32,
+    wind_speed Float32,
+    pressure Float32
+) ENGINE = MergeTree()
+ORDER BY (device_id, timestamp)
+`

--- a/deployment/Iot Service/configmap.yaml
+++ b/deployment/Iot Service/configmap.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: iot-service-config
+  namespace: microservices
+  labels:
+    app: iot-service
+
+data:
+  MQTT_BROKER_URL: "tcp://mosca:1883"
+  MQTT_RAW_TOPIC: "krishi/iot/raw"
+  MQTT_SOIL_TOPIC: "krishi/iot/soil"
+  MQTT_WEATHER_TOPIC: "krishi/iot/weather"
+  CLICKHOUSE_ADDR: "clickhouse:9000"
+  CLICKHOUSE_DATABASE: "krishi_iot"
+  DEVICE_INTERVAL_SECONDS: "10"
+  DEVICE_ID: "krishi-device-001"

--- a/deployment/Iot Service/deployment.yaml
+++ b/deployment/Iot Service/deployment.yaml
@@ -1,0 +1,32 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: iot-service
+  namespace: microservices
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: iot-service
+  template:
+    metadata:
+      labels:
+        app: iot-service
+    spec:
+      containers:
+      - name: iot-service
+        image: your-registry/iot-service:latest
+        imagePullPolicy: Always
+        env:
+        - name: APP_TYPE
+          value: "parser"
+        envFrom:
+        - configMapRef:
+            name: iot-service-config
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+          limits:
+            cpu: 300m
+            memory: 256Mi


### PR DESCRIPTION
### Motivation
- Ensure simulated device payloads include a configurable identifier and guard consumers from ingesting incomplete telemetry. 
- Improve robustness of soil/weather consumers by rejecting messages missing `device_id` or `timestamp` before writing to ClickHouse. 

### Description
- Added `DeviceID` to `config.Config` and load it from the `DEVICE_ID` environment variable with default `krishi-device-001` in `internal/config/config.go`. 
- Use the configured `DeviceID` when producing simulated payloads in `internal/consumers/device.go`. 
- Added validation for `device_id` and `timestamp` to `validateSoil` and `validateWeather` in `internal/consumers/validation.go` to reject incomplete messages. 
- Documented `DEVICE_ID` in `Backend-JS/iot-service/README.md` and added `DEVICE_ID` to the deployment `ConfigMap` at `deployment/Iot Service/configmap.yaml`.

### Testing
- Ran `gofmt -w` on the modified source files which completed successfully. 
- No `go build`/`go test` was executed in this environment because dependency resolution (`go mod tidy`) and external network access are restricted, so compilation and integration tests were not run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69825b8aa674832ab778f901d82527a9)