### PR TITLE
feat(notification): advanced policy engine, digest delivery, channel fallback and preference controls

### DIFF
--- a/Backend-JS/notification-service/.env.example
+++ b/Backend-JS/notification-service/.env.example
@@ -14,6 +14,8 @@ REDIS_PASSWORD=your-redis-password
 RABBITMQ_URL=amqp://guest:guest@10.33.209.124:5673
 RABBITMQ_NOTIFICATION_QUEUE=notifications
 RABBITMQ_BATCH_QUEUE=notification_batches
+RABBITMQ_EVENT_QUEUE=notification_events
+RABBITMQ_EVENT_EXCHANGE=notification.events
 
 # CORS Configuration
 ALLOWED_ORIGINS=http://localhost:3000,http://localhost:8080
@@ -21,6 +23,7 @@ ALLOWED_ORIGINS=http://localhost:3000,http://localhost:8080
 # Batch Processing Configuration
 BATCH_SIZE=100
 BATCH_INTERVAL_MS=60000
+DIGEST_FLUSH_INTERVAL_MS=300000
 
 # Push Notification Configuration (optional)
 WEB_PUSH_VAPID_PUBLIC_KEY=your-vapid-public-key

--- a/Backend-JS/notification-service/src/api/controllers/notification.controller.js
+++ b/Backend-JS/notification-service/src/api/controllers/notification.controller.js
@@ -1,68 +1,46 @@
 const notificationService = require('../../services/notification.service');
 const logger = require('../../utils/logger');
+const eventNotificationService = require('../../services/event-notification.service');
 
 exports.createNotification = async (req, res) => {
   try {
     const notification = await notificationService.createNotification(req.body);
-    res.status(201).json({
-      success: true,
-      data: notification
-    });
+    res.status(201).json({ success: true, data: notification });
   } catch (error) {
     logger.error('Controller error - createNotification:', error);
-    res.status(500).json({
-      success: false,
-      message: 'Failed to create notification',
-      error: error.message
-    });
+    res.status(500).json({ success: false, message: 'Failed to create notification', error: error.message });
   }
 };
 
 exports.createBulkNotifications = async (req, res) => {
   try {
     if (!Array.isArray(req.body.notifications)) {
-      return res.status(400).json({
-        success: false,
-        message: 'Notifications must be an array'
-      });
+      return res.status(400).json({ success: false, message: 'Notifications must be an array' });
     }
 
     const notifications = await notificationService.createBulkNotifications(req.body.notifications);
     res.status(201).json({
       success: true,
       count: notifications.length,
-      message: `Successfully queued ${notifications.length} notifications`
+      message: `Successfully queued ${notifications.length} notifications`,
     });
   } catch (error) {
     logger.error('Controller error - createBulkNotifications:', error);
-    res.status(500).json({
-      success: false,
-      message: 'Failed to create bulk notifications',
-      error: error.message
-    });
+    res.status(500).json({ success: false, message: 'Failed to create bulk notifications', error: error.message });
   }
 };
 
 exports.getUserNotifications = async (req, res) => {
   try {
     const { userId } = req.params;
-    const limit = parseInt(req.query.limit) || 20;
-    const page = parseInt(req.query.page) || 1;
-    
+    const limit = parseInt(req.query.limit, 10) || 20;
+    const page = parseInt(req.query.page, 10) || 1;
+
     const result = await notificationService.getNotificationsForUser(userId, limit, page);
-    
-    res.status(200).json({
-      success: true,
-      data: result.notifications,
-      pagination: result.pagination
-    });
+    res.status(200).json({ success: true, data: result.notifications, pagination: result.pagination });
   } catch (error) {
     logger.error('Controller error - getUserNotifications:', error);
-    res.status(500).json({
-      success: false,
-      message: 'Failed to fetch user notifications',
-      error: error.message
-    });
+    res.status(500).json({ success: false, message: 'Failed to fetch user notifications', error: error.message });
   }
 };
 
@@ -70,18 +48,10 @@ exports.getUserPreferences = async (req, res) => {
   try {
     const { userId } = req.params;
     const preferences = await notificationService.getUserPreferences(userId);
-    
-    res.status(200).json({
-      success: true,
-      data: preferences
-    });
+    res.status(200).json({ success: true, data: preferences });
   } catch (error) {
     logger.error('Controller error - getUserPreferences:', error);
-    res.status(500).json({
-      success: false,
-      message: 'Failed to fetch user preferences',
-      error: error.message
-    });
+    res.status(500).json({ success: false, message: 'Failed to fetch user preferences', error: error.message });
   }
 };
 
@@ -89,18 +59,10 @@ exports.updateUserPreferences = async (req, res) => {
   try {
     const { userId } = req.params;
     const preferences = await notificationService.updateUserPreferences(userId, req.body);
-    
-    res.status(200).json({
-      success: true,
-      data: preferences
-    });
+    res.status(200).json({ success: true, data: preferences });
   } catch (error) {
     logger.error('Controller error - updateUserPreferences:', error);
-    res.status(500).json({
-      success: false,
-      message: 'Failed to update user preferences',
-      error: error.message
-    });
+    res.status(500).json({ success: false, message: 'Failed to update user preferences', error: error.message });
   }
 };
 
@@ -108,24 +70,74 @@ exports.markAsRead = async (req, res) => {
   try {
     const { userId, notificationId } = req.params;
     const notification = await notificationService.markAsRead(notificationId, userId);
-    
+
     if (!notification) {
-      return res.status(404).json({
-        success: false,
-        message: 'Notification not found'
-      });
+      return res.status(404).json({ success: false, message: 'Notification not found' });
     }
-    
-    res.status(200).json({
-      success: true,
-      data: notification
-    });
+
+    res.status(200).json({ success: true, data: notification });
   } catch (error) {
     logger.error('Controller error - markAsRead:', error);
-    res.status(500).json({
-      success: false,
-      message: 'Failed to mark notification as read',
-      error: error.message
-    });
+    res.status(500).json({ success: false, message: 'Failed to mark notification as read', error: error.message });
   }
-}; 
+};
+
+exports.processDomainEvent = async (req, res) => {
+  try {
+    const result = await eventNotificationService.handleEvent(req.body);
+    res.status(202).json({ success: true, data: result });
+  } catch (error) {
+    logger.error('Controller error - processDomainEvent:', error);
+    res.status(400).json({ success: false, message: 'Failed to process domain event', error: error.message });
+  }
+};
+
+exports.mute = async (req, res) => {
+  try {
+    const { userId } = req.params;
+    const data = await notificationService.muteEntities(userId, req.body || {});
+    res.status(200).json({ success: true, data });
+  } catch (error) {
+    logger.error('Controller error - mute:', error);
+    res.status(500).json({ success: false, message: 'Failed to mute notification sources', error: error.message });
+  }
+};
+
+exports.unmute = async (req, res) => {
+  try {
+    const { userId } = req.params;
+    const data = await notificationService.unmuteEntities(userId, req.body || {});
+    res.status(200).json({ success: true, data });
+  } catch (error) {
+    logger.error('Controller error - unmute:', error);
+    res.status(500).json({ success: false, message: 'Failed to unmute notification sources', error: error.message });
+  }
+};
+
+exports.trackInteraction = async (req, res) => {
+  try {
+    const { userId, notificationId } = req.params;
+    const action = req.body?.action || 'clicked';
+    const data = await notificationService.trackNotificationInteraction(notificationId, userId, action);
+
+    if (!data) {
+      return res.status(404).json({ success: false, message: 'Notification not found' });
+    }
+
+    res.status(200).json({ success: true, data });
+  } catch (error) {
+    logger.error('Controller error - trackInteraction:', error);
+    res.status(500).json({ success: false, message: 'Failed to track interaction', error: error.message });
+  }
+};
+
+exports.sendTestNotification = async (req, res) => {
+  try {
+    const { userId } = req.params;
+    const notification = await notificationService.sendTestNotification(userId, req.body || {});
+    res.status(201).json({ success: true, data: notification });
+  } catch (error) {
+    logger.error('Controller error - sendTestNotification:', error);
+    res.status(500).json({ success: false, message: 'Failed to send test notification', error: error.message });
+  }
+};

--- a/Backend-JS/notification-service/src/api/routes.js
+++ b/Backend-JS/notification-service/src/api/routes.js
@@ -1,25 +1,26 @@
 const express = require('express');
 const router = express.Router();
 const notificationController = require('./controllers/notification.controller');
-// const auth = require('../middlewares/auth');
 
-// Notification routes
 router.post('/notifications', notificationController.createNotification);
 router.post('/notifications/bulk', notificationController.createBulkNotifications);
+router.post('/events', notificationController.processDomainEvent);
 router.get('/users/:userId/notifications', notificationController.getUserNotifications);
 router.patch('/users/:userId/notifications/:notificationId/read', notificationController.markAsRead);
+router.patch('/users/:userId/notifications/:notificationId/interaction', notificationController.trackInteraction);
 
-// User preferences routes
 router.get('/users/:userId/preferences', notificationController.getUserPreferences);
 router.put('/users/:userId/preferences', notificationController.updateUserPreferences);
+router.patch('/users/:userId/preferences/mute', notificationController.mute);
+router.patch('/users/:userId/preferences/unmute', notificationController.unmute);
+router.post('/users/:userId/notifications/test', notificationController.sendTestNotification);
 
-// Health check
 router.get('/health', (req, res) => {
   res.status(200).json({
     status: 'ok',
     service: 'notification-service',
-    timestamp: new Date().toISOString()
+    timestamp: new Date().toISOString(),
   });
 });
 
-module.exports = router; 
+module.exports = router;

--- a/Backend-JS/notification-service/src/config/index.js
+++ b/Backend-JS/notification-service/src/config/index.js
@@ -12,13 +12,16 @@ module.exports = {
   },
   rabbitmq: {
     url: process.env.RABBITMQ_URL || 'amqp://localhost:5672',
+    exchange: process.env.RABBITMQ_EVENT_EXCHANGE || 'notification.events',
     queues: {
       notification: process.env.RABBITMQ_NOTIFICATION_QUEUE || 'notifications',
-      batch: process.env.RABBITMQ_BATCH_QUEUE || 'notification_batches'
+      batch: process.env.RABBITMQ_BATCH_QUEUE || 'notification_batches',
+      event: process.env.RABBITMQ_EVENT_QUEUE || 'notification_events'
     }
   },
   batch: {
     size: parseInt(process.env.BATCH_SIZE || '100'),
-    intervalMs: parseInt(process.env.BATCH_INTERVAL_MS || '60000')
+    intervalMs: parseInt(process.env.BATCH_INTERVAL_MS || '60000'),
+    digestFlushIntervalMs: parseInt(process.env.DIGEST_FLUSH_INTERVAL_MS || '300000')
   }
 }; 

--- a/Backend-JS/notification-service/src/config/rabbitmq.js
+++ b/Backend-JS/notification-service/src/config/rabbitmq.js
@@ -9,18 +9,15 @@ const connect = async () => {
   try {
     connection = await amqp.connect(config.rabbitmq.url);
     channel = await connection.createChannel();
-    
-    // Ensure queues exist
-    await channel.assertQueue(config.rabbitmq.queues.notification, { 
-      durable: true 
-    });
-    
-    await channel.assertQueue(config.rabbitmq.queues.batch, { 
-      durable: true 
-    });
-    
+
+    await channel.assertQueue(config.rabbitmq.queues.notification, { durable: true });
+    await channel.assertQueue(config.rabbitmq.queues.batch, { durable: true });
+    await channel.assertQueue(config.rabbitmq.queues.event, { durable: true });
+
+    await channel.assertExchange(config.rabbitmq.exchange, 'topic', { durable: true });
+    await channel.bindQueue(config.rabbitmq.queues.event, config.rabbitmq.exchange, 'notification.event.*');
+
     logger.info('RabbitMQ connected successfully');
-    
     return { connection, channel };
   } catch (error) {
     logger.error('RabbitMQ connection error:', error);
@@ -42,5 +39,5 @@ const disconnect = async () => {
 module.exports = {
   connect,
   getChannel,
-  disconnect
-}; 
+  disconnect,
+};

--- a/Backend-JS/notification-service/src/models/notification.model.js
+++ b/Backend-JS/notification-service/src/models/notification.model.js
@@ -56,6 +56,11 @@ const NotificationSchema = new mongoose.Schema(
       default: Date.now,
       index: true,
     },
+    dedupeKey: {
+      type: String,
+      default: null,
+      index: true,
+    },
     batchId: {
       type: String,
       index: true,
@@ -67,6 +72,18 @@ const NotificationSchema = new mongoose.Schema(
     seenAt: {
       type: Date,
       default: null,
+    },
+    clickedAt: {
+      type: Date,
+      default: null,
+    },
+    actionedAt: {
+      type: Date,
+      default: null,
+    },
+    channelTrail: {
+      type: [String],
+      default: [],
     },
     error: {
       type: String,
@@ -82,16 +99,15 @@ const NotificationSchema = new mongoose.Schema(
   }
 );
 
-// Compound indexes for common query patterns (optimized for 10k users)
-NotificationSchema.index({ userId: 1, createdAt: -1 }); // User notifications list
-NotificationSchema.index({ userId: 1, status: 1, createdAt: -1 }); // User notifications by status
-NotificationSchema.index({ status: 1, scheduledFor: 1 }); // Batch processing
-NotificationSchema.index({ status: 1, scheduledFor: 1, priority: -1 }); // Priority processing
-NotificationSchema.index({ userId: 1, category: 1, createdAt: -1 }); // Category filtering
-NotificationSchema.index({ batchId: 1, status: 1 }); // Batch status tracking
-NotificationSchema.index({ userId: 1, seenAt: 1 }); // Unread notifications
+NotificationSchema.index({ userId: 1, createdAt: -1 });
+NotificationSchema.index({ userId: 1, status: 1, createdAt: -1 });
+NotificationSchema.index({ status: 1, scheduledFor: 1 });
+NotificationSchema.index({ status: 1, scheduledFor: 1, priority: -1 });
+NotificationSchema.index({ userId: 1, category: 1, createdAt: -1 });
+NotificationSchema.index({ batchId: 1, status: 1 });
+NotificationSchema.index({ userId: 1, seenAt: 1 });
+NotificationSchema.index({ dedupeKey: 1, userId: 1, createdAt: -1 });
 
-// Static method to get user notifications
 NotificationSchema.statics.getByUser = function(userId, { page = 1, limit = 20, status = null } = {}) {
   const skip = (page - 1) * limit;
   const query = { userId };
@@ -107,7 +123,6 @@ NotificationSchema.statics.getByUser = function(userId, { page = 1, limit = 20, 
     .lean();
 };
 
-// Static method to count unread notifications
 NotificationSchema.statics.countUnread = function(userId) {
   return this.countDocuments({
     userId,
@@ -116,10 +131,9 @@ NotificationSchema.statics.countUnread = function(userId) {
   });
 };
 
-// Static method to get pending notifications for batch processing
 NotificationSchema.statics.getPendingForBatch = function(limit = 100) {
   return this.find({
-    status: NOTIFICATION_STATUS.PENDING,
+    status: { $in: [NOTIFICATION_STATUS.PENDING, NOTIFICATION_STATUS.DEFERRED] },
     scheduledFor: { $lte: new Date() },
   })
     .sort({ priority: -1, scheduledFor: 1 })
@@ -127,7 +141,6 @@ NotificationSchema.statics.getPendingForBatch = function(limit = 100) {
     .lean();
 };
 
-// Static method to mark as delivered
 NotificationSchema.statics.markDelivered = function(notificationId) {
   return this.findByIdAndUpdate(
     notificationId,
@@ -139,7 +152,6 @@ NotificationSchema.statics.markDelivered = function(notificationId) {
   );
 };
 
-// Static method to mark as seen/read
 NotificationSchema.statics.markSeen = function(notificationId, userId) {
   return this.findOneAndUpdate(
     { _id: notificationId, userId },
@@ -151,7 +163,6 @@ NotificationSchema.statics.markSeen = function(notificationId, userId) {
   );
 };
 
-// Static method to mark multiple as seen
 NotificationSchema.statics.markMultipleSeen = function(userId, notificationIds) {
   return this.updateMany(
     { _id: { $in: notificationIds }, userId },
@@ -162,7 +173,6 @@ NotificationSchema.statics.markMultipleSeen = function(userId, notificationIds) 
   );
 };
 
-// Instance method to mark as failed
 NotificationSchema.methods.markFailed = async function(errorMessage) {
   this.status = NOTIFICATION_STATUS.FAILED;
   this.error = errorMessage;

--- a/Backend-JS/notification-service/src/models/user.model.js
+++ b/Backend-JS/notification-service/src/models/user.model.js
@@ -1,5 +1,5 @@
 const mongoose = require('mongoose');
-const { NOTIFICATION_CATEGORIES } = require('../utils/constants');
+const { NOTIFICATION_DELIVERY_MODE } = require('../utils/constants');
 
 const UserNotificationPreferencesSchema = new mongoose.Schema(
   {
@@ -12,6 +12,11 @@ const UserNotificationPreferencesSchema = new mongoose.Schema(
     enabled: {
       type: Boolean,
       default: true,
+    },
+    locale: {
+      type: String,
+      default: 'en',
+      maxlength: 10,
     },
     channels: {
       push: {
@@ -34,12 +39,57 @@ const UserNotificationPreferencesSchema = new mongoose.Schema(
       },
     },
     categories: {
-      consultant_service: { type: Boolean, default: true },
-      new_post: { type: Boolean, default: true },
-      new_reel: { type: Boolean, default: true },
-      farm_videos: { type: Boolean, default: true },
-      crop_care_ai: { type: Boolean, default: true },
       system: { type: Boolean, default: true },
+      subscription: { type: Boolean, default: true },
+      promotion: { type: Boolean, default: true },
+      advertisement: { type: Boolean, default: true },
+      post_engagement: { type: Boolean, default: true },
+      reel_engagement: { type: Boolean, default: true },
+      marketplace: { type: Boolean, default: true },
+      consultant_service: { type: Boolean, default: true },
+      message: { type: Boolean, default: true },
+    },
+    interests: {
+      crops: { type: [String], default: [] },
+      livestock: { type: [String], default: [] },
+      marketplaceTags: { type: [String], default: [] },
+      contentTopics: { type: [String], default: [] },
+      locations: { type: [String], default: [] },
+    },
+    muted: {
+      actorIds: { type: [String], default: [] },
+      entityIds: { type: [String], default: [] },
+      categories: { type: [String], default: [] },
+    },
+    delivery: {
+      defaultMode: {
+        type: String,
+        enum: Object.values(NOTIFICATION_DELIVERY_MODE),
+        default: NOTIFICATION_DELIVERY_MODE.INSTANT,
+      },
+      categoryModes: {
+        type: Map,
+        of: {
+          type: String,
+          enum: Object.values(NOTIFICATION_DELIVERY_MODE),
+        },
+        default: {},
+      },
+      digest: {
+        enabled: { type: Boolean, default: true },
+        frequencyMinutes: { type: Number, default: 60, min: 15, max: 1440 },
+      },
+      channelFallback: {
+        enabled: { type: Boolean, default: true },
+      },
+    },
+    frequencyCaps: {
+      type: Map,
+      of: {
+        limit: { type: Number, min: 1, default: 20 },
+        windowSeconds: { type: Number, min: 60, default: 3600 },
+      },
+      default: {},
     },
     quietHours: {
       enabled: { type: Boolean, default: false },
@@ -57,11 +107,9 @@ const UserNotificationPreferencesSchema = new mongoose.Schema(
   }
 );
 
-// Indexes for efficient queries (optimized for 10k users)
 UserNotificationPreferencesSchema.index({ 'channels.push.token': 1 });
 UserNotificationPreferencesSchema.index({ enabled: 1 });
 
-// Static method to get or create preferences
 UserNotificationPreferencesSchema.statics.getOrCreate = async function(userId) {
   let preferences = await this.findOne({ userId });
 
@@ -72,7 +120,6 @@ UserNotificationPreferencesSchema.statics.getOrCreate = async function(userId) {
   return preferences;
 };
 
-// Static method to update push token
 UserNotificationPreferencesSchema.statics.updatePushToken = function(userId, token, platform) {
   return this.findOneAndUpdate(
     { userId },
@@ -85,30 +132,36 @@ UserNotificationPreferencesSchema.statics.updatePushToken = function(userId, tok
   );
 };
 
-// Static method to get users by category preference
 UserNotificationPreferencesSchema.statics.getUsersForCategory = function(category, limit = 1000) {
   return this.find({
     enabled: true,
-    [`categories.${category}`]: true,
+    [`categories.${category}`]: { $ne: false },
+    'muted.categories': { $ne: category },
   })
-    .select('userId channels')
+    .select('userId channels interests muted delivery frequencyCaps locale')
     .limit(limit)
     .lean();
 };
 
-// Instance method to check if category is enabled
 UserNotificationPreferencesSchema.methods.isCategoryEnabled = function(category) {
   if (!this.enabled) return false;
-  return this.categories[category] !== false;
+  if (this.muted?.categories?.includes(category)) return false;
+  return this.categories?.[category] !== false;
 };
 
-// Instance method to check if channel is enabled
 UserNotificationPreferencesSchema.methods.isChannelEnabled = function(channel) {
   if (!this.enabled) return false;
-  return this.channels[channel]?.enabled !== false;
+  return this.channels?.[channel]?.enabled !== false;
 };
 
-// Instance method to check if in quiet hours
+UserNotificationPreferencesSchema.methods.isEntityMuted = function(entityId, actorId) {
+  if (!this.muted) return false;
+  return Boolean(
+    (entityId && this.muted.entityIds?.includes(entityId)) ||
+    (actorId && this.muted.actorIds?.includes(actorId))
+  );
+};
+
 UserNotificationPreferencesSchema.methods.isInQuietHours = function() {
   if (!this.quietHours.enabled) return false;
 
@@ -124,7 +177,6 @@ UserNotificationPreferencesSchema.methods.isInQuietHours = function() {
   const startTime = this.quietHours.start.replace(':', '');
   const endTime = this.quietHours.end.replace(':', '');
 
-  // Handle overnight quiet hours (e.g., 22:00 to 07:00)
   if (startTime > endTime) {
     return currentTime >= startTime || currentTime < endTime;
   }

--- a/Backend-JS/notification-service/src/services/__tests__/event-template.service.test.js
+++ b/Backend-JS/notification-service/src/services/__tests__/event-template.service.test.js
@@ -1,0 +1,51 @@
+const eventTemplateService = require('../event-template.service');
+const {
+  NOTIFICATION_CATEGORIES,
+  NOTIFICATION_EVENTS,
+  NOTIFICATION_STATUS,
+} = require('../../utils/constants');
+
+describe('event-template.service', () => {
+  test('builds subscription ending notification from event payload', () => {
+    const notification = eventTemplateService.buildNotificationFromEvent({
+      type: NOTIFICATION_EVENTS.SUBSCRIPTION_ENDING,
+      payload: { planName: 'Gold Plan', daysLeft: 3 },
+    }, 'user-1');
+
+    expect(notification.userId).toBe('user-1');
+    expect(notification.category).toBe(NOTIFICATION_CATEGORIES.SUBSCRIPTION);
+    expect(notification.title).toContain('Gold Plan');
+    expect(notification.body).toContain('3');
+    expect(notification.status).toBe(NOTIFICATION_STATUS.PENDING);
+  });
+
+  test('throws for unsupported event type', () => {
+    expect(() => eventTemplateService.buildNotificationFromEvent({
+      type: 'unsupported.event',
+      payload: {},
+    }, 'user-1')).toThrow('Unsupported notification event type');
+  });
+
+  test('matches user interests using event filters', () => {
+    const preferences = {
+      interests: {
+        marketplaceTags: ['seeds', 'fertilizer'],
+      },
+    };
+
+    const shouldMatch = eventTemplateService.isInterestMatch(preferences, {
+      interestFilters: {
+        marketplaceTags: ['fertilizer'],
+      },
+    });
+
+    const shouldNotMatch = eventTemplateService.isInterestMatch(preferences, {
+      interestFilters: {
+        marketplaceTags: ['tractor'],
+      },
+    });
+
+    expect(shouldMatch).toBe(true);
+    expect(shouldNotMatch).toBe(false);
+  });
+});

--- a/Backend-JS/notification-service/src/services/__tests__/notification-policy.service.test.js
+++ b/Backend-JS/notification-service/src/services/__tests__/notification-policy.service.test.js
@@ -1,0 +1,53 @@
+jest.mock('../../config/redis', () => {
+  const store = new Map();
+  return {
+    get: jest.fn(async (key) => store.get(key) || null),
+    set: jest.fn(async (key, value) => {
+      store.set(key, value);
+      return 'OK';
+    }),
+    client: {
+      incr: jest.fn(async (key) => {
+        const current = parseInt(store.get(key) || '0', 10) + 1;
+        store.set(key, String(current));
+        return current;
+      }),
+      expire: jest.fn(async () => 1),
+    },
+  };
+});
+
+const policyService = require('../notification-policy.service');
+
+describe('notification-policy.service', () => {
+  test('detects duplicate notifications within dedupe window', async () => {
+    const notification = {
+      userId: 'user-1',
+      category: 'promotion',
+      data: { eventType: 'subscription.discount', entityId: 'plan-1', actorId: 'sys' },
+    };
+
+    const first = await policyService.isDuplicate({ ...notification });
+    const second = await policyService.isDuplicate({ ...notification });
+
+    expect(first).toBe(false);
+    expect(second).toBe(true);
+  });
+
+  test('respects mute rules for actor/entity/category', () => {
+    const notification = {
+      category: 'advertisement',
+      data: { actorId: 'actor-1', entityId: 'entity-1' },
+    };
+
+    const preferences = {
+      muted: {
+        categories: ['advertisement'],
+        actorIds: [],
+        entityIds: [],
+      },
+    };
+
+    expect(policyService.isMuted(notification, preferences)).toBe(true);
+  });
+});

--- a/Backend-JS/notification-service/src/services/digest.service.js
+++ b/Backend-JS/notification-service/src/services/digest.service.js
@@ -1,0 +1,88 @@
+const redis = require('../config/redis');
+const Notification = require('../models/notification.model');
+const queueService = require('./queue.service');
+const logger = require('../utils/logger');
+const {
+  CACHE_KEYS,
+  CACHE_TTL,
+  NOTIFICATION_PRIORITY,
+  NOTIFICATION_STATUS,
+  NOTIFICATION_TYPES,
+} = require('../utils/constants');
+
+class DigestService {
+  _digestKey(userId, category) {
+    return `${CACHE_KEYS.DIGEST}${userId}:${category}`;
+  }
+
+  async enqueue(notification) {
+    const key = this._digestKey(notification.userId, notification.category);
+    const payload = {
+      title: notification.title,
+      body: notification.body,
+      data: notification.data,
+      createdAt: new Date().toISOString(),
+    };
+
+    const existing = await redis.get(key);
+    const parsed = existing ? JSON.parse(existing) : { items: [], meta: {} };
+
+    parsed.items.push(payload);
+    parsed.meta = {
+      userId: notification.userId,
+      category: notification.category,
+      updatedAt: new Date().toISOString(),
+    };
+
+    await redis.setex(key, CACHE_TTL.DIGEST_WINDOW, JSON.stringify(parsed));
+    return parsed.items.length;
+  }
+
+  async flushDigests(limit = 500) {
+    const keys = await redis.keys(`${CACHE_KEYS.DIGEST}*`);
+    const selected = keys.slice(0, limit);
+    let flushed = 0;
+
+    for (const key of selected) {
+      try {
+        const raw = await redis.get(key);
+        if (!raw) continue;
+
+        const digest = JSON.parse(raw);
+        if (!digest.items || !digest.items.length) {
+          await redis.del(key);
+          continue;
+        }
+
+        const [userId, category] = key.replace(CACHE_KEYS.DIGEST, '').split(':');
+        const title = `You have ${digest.items.length} new ${(category || 'activity').replace('_', ' ')} updates`;
+        const body = digest.items.slice(0, 3).map((item) => item.body).join(' • ');
+
+        const notification = await Notification.create({
+          userId,
+          type: NOTIFICATION_TYPES.IN_APP,
+          title,
+          body,
+          category,
+          priority: NOTIFICATION_PRIORITY.LOW,
+          status: NOTIFICATION_STATUS.PENDING,
+          data: {
+            digest: true,
+            count: digest.items.length,
+            items: digest.items,
+          },
+        });
+
+        await queueService.sendToNotificationQueue(notification);
+        await redis.del(key);
+        flushed += 1;
+      } catch (error) {
+        logger.error('Digest flush failed:', error.message);
+      }
+    }
+
+    return flushed;
+  }
+}
+
+module.exports = new DigestService();

--- a/Backend-JS/notification-service/src/services/event-notification.service.js
+++ b/Backend-JS/notification-service/src/services/event-notification.service.js
@@ -1,0 +1,116 @@
+const Notification = require('../models/notification.model');
+const UserNotificationPreferences = require('../models/user.model');
+const queueService = require('./queue.service');
+const eventTemplateService = require('./event-template.service');
+const notificationPolicyService = require('./notification-policy.service');
+const digestService = require('./digest.service');
+const logger = require('../utils/logger');
+const { NOTIFICATION_DELIVERY_MODE } = require('../utils/constants');
+
+class EventNotificationService {
+  async handleEvent(event) {
+    if (!event || !event.type) {
+      throw new Error('Invalid event payload. `type` is required.');
+    }
+
+    const template = eventTemplateService.getTemplate(event.type);
+    if (!template) {
+      throw new Error(`Unsupported notification event type: ${event.type}`);
+    }
+
+    const recipientIds = await this._resolveRecipients(event, template);
+    if (!recipientIds.length) {
+      logger.info(`No recipients found for event ${event.type}`);
+      return { processed: 0, reason: 'NO_RECIPIENTS' };
+    }
+
+    const preferences = await UserNotificationPreferences.find({
+      userId: { $in: recipientIds },
+      enabled: true,
+    }).lean();
+
+    const preferenceByUser = new Map(preferences.map((pref) => [pref.userId, pref]));
+    const notifications = [];
+    let digestQueued = 0;
+
+    for (const userId of recipientIds) {
+      const userPreferences = preferenceByUser.get(userId);
+      if (!userPreferences) continue;
+
+      const category = event.category || template.category;
+      if (category && userPreferences.categories?.[category] === false) {
+        continue;
+      }
+
+      if (!eventTemplateService.isInterestMatch(userPreferences, event)) {
+        continue;
+      }
+
+      const notification = eventTemplateService.buildNotificationFromEvent(
+        event,
+        userId,
+        userPreferences.locale || 'en'
+      );
+
+      if (notificationPolicyService.isMuted(notification, userPreferences)) {
+        continue;
+      }
+
+      if (await notificationPolicyService.isDuplicate(notification)) {
+        continue;
+      }
+
+      if (await notificationPolicyService.isRateLimited(notification, userPreferences)) {
+        continue;
+      }
+
+      const deliveryMode = this._resolveDeliveryMode(userPreferences, notification.category);
+      if (deliveryMode === NOTIFICATION_DELIVERY_MODE.DIGEST && notification.priority !== 'high') {
+        await digestService.enqueue(notification);
+        digestQueued += 1;
+        continue;
+      }
+
+      notifications.push(notification);
+    }
+
+    if (!notifications.length && !digestQueued) {
+      return { processed: 0, reason: 'FILTERED_OUT' };
+    }
+
+    let created = [];
+    if (notifications.length) {
+      created = await Notification.insertMany(notifications);
+      await queueService.sendToBatchQueue(created);
+      logger.info(`Generated ${created.length} instant notifications for event ${event.type}`);
+    }
+
+    return { processed: created.length, digestQueued, reason: 'OK' };
+  }
+
+  _resolveDeliveryMode(preferences, category) {
+    const categoryMode = preferences?.delivery?.categoryModes?.[category];
+    return categoryMode || preferences?.delivery?.defaultMode || NOTIFICATION_DELIVERY_MODE.INSTANT;
+  }
+
+  async _resolveRecipients(event, template) {
+    if (Array.isArray(event.recipientIds) && event.recipientIds.length) {
+      return [...new Set(event.recipientIds.filter(Boolean))];
+    }
+
+    const category = event.category || template.category;
+
+    if (!category) {
+      return [];
+    }
+
+    const safeLimit = Number.isFinite(event.recipientLimit)
+      ? Math.max(1, Math.min(event.recipientLimit, 10000))
+      : 5000;
+
+    const users = await UserNotificationPreferences.getUsersForCategory(category, safeLimit);
+    return users.map((user) => user.userId);
+  }
+}
+
+module.exports = new EventNotificationService();

--- a/Backend-JS/notification-service/src/services/event-template.service.js
+++ b/Backend-JS/notification-service/src/services/event-template.service.js
@@ -1,0 +1,125 @@
+const {
+  NOTIFICATION_CATEGORIES,
+  NOTIFICATION_EVENTS,
+  NOTIFICATION_PRIORITY,
+  NOTIFICATION_STATUS,
+  NOTIFICATION_TYPES,
+} = require('../utils/constants');
+
+const EVENT_TEMPLATE_MAP = {
+  [NOTIFICATION_EVENTS.SUBSCRIPTION_ENDING]: {
+    category: NOTIFICATION_CATEGORIES.SUBSCRIPTION,
+    priority: NOTIFICATION_PRIORITY.HIGH,
+    defaultType: NOTIFICATION_TYPES.PUSH,
+    fallbackChannels: [NOTIFICATION_TYPES.IN_APP, NOTIFICATION_TYPES.EMAIL],
+    title: ({ planName = 'your plan' }) => `${planName} expires soon`,
+    body: ({ daysLeft = 0 }) => `Your subscription ends in ${daysLeft} day(s). Renew now to avoid interruption.`,
+  },
+  [NOTIFICATION_EVENTS.SUBSCRIPTION_DISCOUNT]: {
+    category: NOTIFICATION_CATEGORIES.PROMOTION,
+    priority: NOTIFICATION_PRIORITY.MEDIUM,
+    defaultType: NOTIFICATION_TYPES.PUSH,
+    fallbackChannels: [NOTIFICATION_TYPES.IN_APP],
+    title: ({ discountPercent = 0 }) => `${discountPercent}% discount on subscription`,
+    body: ({ planName = 'premium plan' }) => `Limited-time offer available for ${planName}. Upgrade today.`,
+  },
+  [NOTIFICATION_EVENTS.ADVERTISEMENT_BROADCAST]: {
+    category: NOTIFICATION_CATEGORIES.ADVERTISEMENT,
+    priority: NOTIFICATION_PRIORITY.LOW,
+    defaultType: NOTIFICATION_TYPES.IN_APP,
+    fallbackChannels: [],
+    title: ({ campaignName = 'New campaign' }) => campaignName,
+    body: ({ message = 'Check new offers tailored for you.' }) => message,
+  },
+  [NOTIFICATION_EVENTS.POST_LIKED]: {
+    category: NOTIFICATION_CATEGORIES.POST_ENGAGEMENT,
+    priority: NOTIFICATION_PRIORITY.LOW,
+    defaultType: NOTIFICATION_TYPES.IN_APP,
+    fallbackChannels: [],
+    title: ({ actorName = 'Someone' }) => `${actorName} liked your post`,
+    body: () => 'Your post is getting engagement. Tap to view activity.',
+  },
+  [NOTIFICATION_EVENTS.POST_COMMENTED]: {
+    category: NOTIFICATION_CATEGORIES.POST_ENGAGEMENT,
+    priority: NOTIFICATION_PRIORITY.MEDIUM,
+    defaultType: NOTIFICATION_TYPES.PUSH,
+    fallbackChannels: [NOTIFICATION_TYPES.IN_APP],
+    title: ({ actorName = 'Someone' }) => `${actorName} commented on your post`,
+    body: ({ commentSnippet = '' }) => commentSnippet || 'Open to read and reply to the comment.',
+  },
+  [NOTIFICATION_EVENTS.REEL_LIKED]: {
+    category: NOTIFICATION_CATEGORIES.REEL_ENGAGEMENT,
+    priority: NOTIFICATION_PRIORITY.LOW,
+    defaultType: NOTIFICATION_TYPES.IN_APP,
+    fallbackChannels: [],
+    title: ({ actorName = 'Someone' }) => `${actorName} liked your reel`,
+    body: () => 'Your reel is gaining traction. See your latest reactions.',
+  },
+  [NOTIFICATION_EVENTS.REEL_COMMENTED]: {
+    category: NOTIFICATION_CATEGORIES.REEL_ENGAGEMENT,
+    priority: NOTIFICATION_PRIORITY.MEDIUM,
+    defaultType: NOTIFICATION_TYPES.PUSH,
+    fallbackChannels: [NOTIFICATION_TYPES.IN_APP],
+    title: ({ actorName = 'Someone' }) => `${actorName} commented on your reel`,
+    body: ({ commentSnippet = '' }) => commentSnippet || 'Open the reel to view and respond.',
+  },
+  [NOTIFICATION_EVENTS.MARKETPLACE_PRODUCT_MATCH]: {
+    category: NOTIFICATION_CATEGORIES.MARKETPLACE,
+    priority: NOTIFICATION_PRIORITY.MEDIUM,
+    defaultType: NOTIFICATION_TYPES.PUSH,
+    fallbackChannels: [NOTIFICATION_TYPES.IN_APP],
+    title: ({ productName = 'A product' }) => `${productName} matches your interests`,
+    body: ({ location = '' }) => (location ? `Now available near ${location}.` : 'A new matching product is now available.'),
+  },
+};
+
+class EventTemplateService {
+  getTemplate(eventType) {
+    return EVENT_TEMPLATE_MAP[eventType] || null;
+  }
+
+  buildNotificationFromEvent(event, userId, locale = 'en') {
+    const template = this.getTemplate(event.type);
+    if (!template) {
+      throw new Error(`Unsupported notification event type: ${event.type}`);
+    }
+
+    const payload = event.payload || {};
+    return {
+      userId,
+      title: event.title || template.title(payload, locale),
+      body: event.body || template.body(payload, locale),
+      type: event.channel || template.defaultType,
+      fallbackChannels: event.fallbackChannels || template.fallbackChannels,
+      category: event.category || template.category,
+      priority: event.priority || template.priority,
+      data: {
+        ...payload,
+        eventType: event.type,
+        source: event.source || 'unknown',
+        actionUrl: payload.actionUrl || null,
+        actorId: payload.actorId || null,
+        entityId: payload.entityId || null,
+      },
+      scheduledFor: event.scheduledFor ? new Date(event.scheduledFor) : new Date(),
+      status: NOTIFICATION_STATUS.PENDING,
+    };
+  }
+
+  isInterestMatch(preferences, event) {
+    const filters = event.interestFilters || {};
+    const userInterests = preferences?.interests || {};
+
+    const keys = Object.keys(filters);
+    if (!keys.length) return true;
+
+    return keys.every((key) => {
+      const expected = Array.isArray(filters[key]) ? filters[key] : [filters[key]];
+      const actual = Array.isArray(userInterests[key]) ? userInterests[key] : [];
+      if (!expected.length) return true;
+      return expected.some((value) => actual.includes(value));
+    });
+  }
+}
+
+module.exports = new EventTemplateService();

--- a/Backend-JS/notification-service/src/services/notification-policy.service.js
+++ b/Backend-JS/notification-service/src/services/notification-policy.service.js
@@ -1,0 +1,54 @@
+const redis = require('../config/redis');
+const { CACHE_KEYS, CACHE_TTL, DEFAULT_CATEGORY_CAPS } = require('../utils/constants');
+
+class NotificationPolicyService {
+  _buildDedupeKey(notification) {
+    const eventType = notification?.data?.eventType || 'generic';
+    const entityId = notification?.data?.entityId || 'none';
+    const actorId = notification?.data?.actorId || 'none';
+    return `${notification.userId}:${eventType}:${entityId}:${actorId}`;
+  }
+
+  async isDuplicate(notification) {
+    const dedupeKey = notification.dedupeKey || this._buildDedupeKey(notification);
+    const cacheKey = `${CACHE_KEYS.DEDUPE}${dedupeKey}`;
+    const existing = await redis.get(cacheKey);
+    if (existing) {
+      return true;
+    }
+
+    await redis.set(cacheKey, '1', 'EX', CACHE_TTL.DEDUPE);
+    notification.dedupeKey = dedupeKey;
+    return false;
+  }
+
+  async isRateLimited(notification, preferences = {}) {
+    const category = notification.category || 'system';
+    const caps = preferences.frequencyCaps || {};
+    const customCap = caps[category] || (typeof caps.get === 'function' ? caps.get(category) : null);
+    const defaultCap = DEFAULT_CATEGORY_CAPS[category] || { limit: 30, windowSeconds: 3600 };
+    const cap = customCap || defaultCap;
+
+    const key = `${CACHE_KEYS.RATE_LIMIT}${notification.userId}:${category}`;
+    const counter = await redis.client.incr(key);
+    if (counter === 1) {
+      await redis.client.expire(key, cap.windowSeconds);
+    }
+
+    return counter > cap.limit;
+  }
+
+  isMuted(notification, preferences = {}) {
+    const muted = preferences.muted || {};
+    const entityId = notification?.data?.entityId;
+    const actorId = notification?.data?.actorId;
+
+    const categoryMuted = muted.categories?.includes(notification.category);
+    const actorMuted = actorId && muted.actorIds?.includes(actorId);
+    const entityMuted = entityId && muted.entityIds?.includes(entityId);
+
+    return Boolean(categoryMuted || actorMuted || entityMuted);
+  }
+}
+
+module.exports = new NotificationPolicyService();

--- a/Backend-JS/notification-service/src/services/notification.service.js
+++ b/Backend-JS/notification-service/src/services/notification.service.js
@@ -221,6 +221,83 @@ class NotificationService {
       throw error;
     }
   }
+
+  async muteEntities(userId, { actorIds = [], entityIds = [], categories = [] }) {
+    try {
+      const update = {
+        $addToSet: {
+          'muted.actorIds': { $each: actorIds },
+          'muted.entityIds': { $each: entityIds },
+          'muted.categories': { $each: categories },
+        },
+      };
+
+      const updatedPreferences = await UserNotificationPreferences.findOneAndUpdate(
+        { userId },
+        update,
+        { new: true, upsert: true }
+      );
+
+      await redis.setex(`${CACHE_KEYS.USER_PREFS}${userId}`, CACHE_TTL.USER_PREFS, JSON.stringify(updatedPreferences));
+      return updatedPreferences;
+    } catch (error) {
+      logger.error('Error muting entities/categories:', error.message);
+      throw error;
+    }
+  }
+
+  async unmuteEntities(userId, { actorIds = [], entityIds = [], categories = [] }) {
+    try {
+      const update = {
+        $pullAll: {
+          'muted.actorIds': actorIds,
+          'muted.entityIds': entityIds,
+          'muted.categories': categories,
+        },
+      };
+
+      const updatedPreferences = await UserNotificationPreferences.findOneAndUpdate(
+        { userId },
+        update,
+        { new: true, upsert: true }
+      );
+
+      await redis.setex(`${CACHE_KEYS.USER_PREFS}${userId}`, CACHE_TTL.USER_PREFS, JSON.stringify(updatedPreferences));
+      return updatedPreferences;
+    } catch (error) {
+      logger.error('Error unmuting entities/categories:', error.message);
+      throw error;
+    }
+  }
+
+  async trackNotificationInteraction(notificationId, userId, action = 'clicked') {
+    const update = { updatedAt: new Date() };
+    if (action === 'clicked') update.clickedAt = new Date();
+    if (action === 'actioned') update.actionedAt = new Date();
+
+    const notification = await Notification.findOneAndUpdate(
+      { _id: notificationId, userId },
+      update,
+      { new: true }
+    );
+
+    return notification;
+  }
+
+  async sendTestNotification(userId, payload = {}) {
+    return this.createNotification({
+      userId,
+      type: payload.type || 'in_app',
+      title: payload.title || 'Test notification',
+      body: payload.body || 'This is a test notification from notification-service.',
+      category: payload.category || 'system',
+      priority: payload.priority || 'low',
+      data: {
+        ...(payload.data || {}),
+        isTest: true,
+      },
+    });
+  }
 }
 
 module.exports = new NotificationService();

--- a/Backend-JS/notification-service/src/services/queue.service.js
+++ b/Backend-JS/notification-service/src/services/queue.service.js
@@ -7,16 +7,16 @@ class QueueService {
     try {
       const channel = rabbitmq.getChannel();
       const message = JSON.stringify(notification);
-      
+
       await channel.sendToQueue(
         config.rabbitmq.queues.notification,
         Buffer.from(message),
-        { 
+        {
           persistent: true,
-          priority: this._getPriorityValue(notification.priority)
+          priority: this._getPriorityValue(notification.priority),
         }
       );
-      
+
       logger.debug(`Notification sent to queue: ${notification._id}`);
     } catch (error) {
       logger.error('Error sending to notification queue:', error);
@@ -28,25 +28,24 @@ class QueueService {
     try {
       const channel = rabbitmq.getChannel();
       const batchId = new Date().getTime().toString();
-      
-      // Add batch ID to each notification
-      const batchedNotifications = notifications.map(notification => ({
+
+      const batchedNotifications = notifications.map((notification) => ({
         ...notification.toObject(),
-        batchId
+        batchId,
       }));
-      
+
       const message = JSON.stringify({
         batchId,
         count: batchedNotifications.length,
-        notifications: batchedNotifications
+        notifications: batchedNotifications,
       });
-      
+
       await channel.sendToQueue(
         config.rabbitmq.queues.batch,
         Buffer.from(message),
         { persistent: true }
       );
-      
+
       logger.debug(`Batch sent to queue: ${batchId} with ${batchedNotifications.length} notifications`);
       return batchId;
     } catch (error) {
@@ -55,8 +54,26 @@ class QueueService {
     }
   }
 
+  async publishEvent(eventType, payload) {
+    try {
+      const channel = rabbitmq.getChannel();
+      const message = JSON.stringify(payload);
+      const routingKey = `notification.event.${eventType}`;
+
+      channel.publish(config.rabbitmq.exchange, routingKey, Buffer.from(message), {
+        persistent: true,
+        contentType: 'application/json',
+      });
+
+      logger.info(`Event published to exchange: ${routingKey}`);
+    } catch (error) {
+      logger.error('Error publishing notification event:', error);
+      throw error;
+    }
+  }
+
   _getPriorityValue(priority) {
-    switch(priority) {
+    switch (priority) {
       case 'high': return 3;
       case 'medium': return 2;
       case 'low': return 1;
@@ -65,4 +82,4 @@ class QueueService {
   }
 }
 
-module.exports = new QueueService(); 
+module.exports = new QueueService();

--- a/Backend-JS/notification-service/src/utils/constants.js
+++ b/Backend-JS/notification-service/src/utils/constants.js
@@ -21,11 +21,13 @@ const HTTP_STATUS = {
 };
 
 const CACHE_TTL = {
-  SHORT: 60,           // 1 minute
-  MEDIUM: 300,         // 5 minutes
-  LONG: 3600,          // 1 hour
-  USER_PREFS: 3600,    // 1 hour for user preferences
-  NOTIFICATION: 300,   // 5 minutes for notification data
+  SHORT: 60,
+  MEDIUM: 300,
+  LONG: 3600,
+  USER_PREFS: 3600,
+  NOTIFICATION: 300,
+  DEDUPE: 1800,
+  DIGEST_WINDOW: 3600,
 };
 
 const CACHE_KEYS = {
@@ -33,6 +35,9 @@ const CACHE_KEYS = {
   NOTIFICATION: 'notification:',
   USER_NOTIFICATIONS: 'user_notifications:',
   UNREAD_COUNT: 'unread_count:',
+  DEDUPE: 'dedupe:',
+  RATE_LIMIT: 'notif_rate:',
+  DIGEST: 'digest:',
 };
 
 const PAGINATION = {
@@ -42,26 +47,31 @@ const PAGINATION = {
 };
 
 const RATE_LIMITS = {
-  // General API limits - optimized for 10k users
-  WINDOW_MS: 60 * 1000,        // 1 minute window
-  MAX_REQUESTS: 100,           // 100 requests per window
-
-  // Notification creation limits
+  WINDOW_MS: 60 * 1000,
+  MAX_REQUESTS: 100,
   CREATE_WINDOW_MS: 60 * 1000,
-  MAX_CREATE: 50,              // 50 notifications per minute
-
-  // Bulk notification limits
+  MAX_CREATE: 50,
   BULK_WINDOW_MS: 60 * 1000,
-  MAX_BULK: 10,                // 10 bulk requests per minute
-  MAX_BULK_SIZE: 1000,         // Max 1000 notifications per bulk request
-
-  // WebSocket limits
+  MAX_BULK: 10,
+  MAX_BULK_SIZE: 1000,
   WS_EVENTS_PER_SECOND: 10,
   WS_MAX_CONNECTIONS_PER_USER: 3,
 };
 
+const NOTIFICATION_DELIVERY_MODE = {
+  INSTANT: 'instant',
+  DIGEST: 'digest',
+};
+
+const DEFAULT_CATEGORY_CAPS = {
+  advertisement: { limit: 3, windowSeconds: 3600 },
+  promotion: { limit: 3, windowSeconds: 3600 },
+  post_engagement: { limit: 20, windowSeconds: 3600 },
+  reel_engagement: { limit: 20, windowSeconds: 3600 },
+  marketplace: { limit: 10, windowSeconds: 3600 },
+};
+
 const DB_CONFIG = {
-  // Optimized for 10k concurrent connections
   MAX_POOL_SIZE: 100,
   MIN_POOL_SIZE: 20,
   SOCKET_TIMEOUT_MS: 45000,
@@ -72,10 +82,9 @@ const DB_CONFIG = {
 };
 
 const WEBSOCKET_CONFIG = {
-  // Optimized for 10k concurrent WebSocket connections
   PING_INTERVAL: 25000,
   PING_TIMEOUT: 60000,
-  MAX_PAYLOAD: 10 * 1024,      // 10KB max message size
+  MAX_PAYLOAD: 10 * 1024,
   MAX_CONNECTIONS_PER_USER: 3,
   RECONNECTION_DELAY: 1000,
   RECONNECTION_DELAY_MAX: 5000,
@@ -94,6 +103,8 @@ const NOTIFICATION_STATUS = {
   DELIVERED: 'delivered',
   FAILED: 'failed',
   READ: 'read',
+  SKIPPED: 'skipped',
+  DEFERRED: 'deferred',
 };
 
 const NOTIFICATION_PRIORITY = {
@@ -104,26 +115,38 @@ const NOTIFICATION_PRIORITY = {
 
 const NOTIFICATION_CATEGORIES = {
   SYSTEM: 'system',
+  SUBSCRIPTION: 'subscription',
+  PROMOTION: 'promotion',
+  ADVERTISEMENT: 'advertisement',
+  POST_ENGAGEMENT: 'post_engagement',
+  REEL_ENGAGEMENT: 'reel_engagement',
+  MARKETPLACE: 'marketplace',
   CONSULTANT_SERVICE: 'consultant_service',
-  NEW_POST: 'new_post',
-  LIKE: 'new_post',
-  COMMENT: 'new_post',
-  NEW_REEL: 'new_reel',
-  FARM_VIDEOS: 'farm_videos',
-  CROP_CARE_AI: 'crop_care_ai',
-  MESSAGE: 'consultant_service',
+  MESSAGE: 'message',
+};
+
+const NOTIFICATION_EVENTS = {
+  SUBSCRIPTION_ENDING: 'subscription.ending',
+  SUBSCRIPTION_DISCOUNT: 'subscription.discount',
+  ADVERTISEMENT_BROADCAST: 'advertisement.broadcast',
+  POST_LIKED: 'post.liked',
+  POST_COMMENTED: 'post.commented',
+  REEL_LIKED: 'reel.liked',
+  REEL_COMMENTED: 'reel.commented',
+  MARKETPLACE_PRODUCT_MATCH: 'marketplace.product.match',
 };
 
 const BATCH_CONFIG = {
   DEFAULT_SIZE: 100,
   MAX_SIZE: 1000,
-  DEFAULT_INTERVAL_MS: 60000,  // 1 minute
-  MIN_INTERVAL_MS: 10000,      // 10 seconds minimum
+  DEFAULT_INTERVAL_MS: 60000,
+  MIN_INTERVAL_MS: 10000,
+  DIGEST_FLUSH_INTERVAL_MS: 300000,
 };
 
 const RABBITMQ_CONFIG = {
-  PREFETCH_COUNT: 10,          // Process 10 messages at a time for better throughput
-  MESSAGE_TTL: 86400000,       // 24 hours
+  PREFETCH_COUNT: 10,
+  MESSAGE_TTL: 86400000,
   MAX_RETRIES: 3,
   RETRY_DELAY: 1000,
 };
@@ -140,6 +163,9 @@ module.exports = {
   NOTIFICATION_STATUS,
   NOTIFICATION_PRIORITY,
   NOTIFICATION_CATEGORIES,
+  NOTIFICATION_EVENTS,
+  NOTIFICATION_DELIVERY_MODE,
+  DEFAULT_CATEGORY_CAPS,
   BATCH_CONFIG,
   RABBITMQ_CONFIG,
 };

--- a/Backend-JS/notification-service/src/workers/batch-processor.js
+++ b/Backend-JS/notification-service/src/workers/batch-processor.js
@@ -2,30 +2,27 @@ const rabbitmq = require('../config/rabbitmq');
 const config = require('../config');
 const Notification = require('../models/notification.model');
 const processor = require('./processor');
+const eventNotificationService = require('../services/event-notification.service');
 const logger = require('../utils/logger');
+const digestService = require('../services/digest.service');
+const { NOTIFICATION_STATUS } = require('../utils/constants');
 
 class BatchProcessor {
   async startConsumer() {
     try {
       const channel = rabbitmq.getChannel();
-      
-      // Set prefetch to control concurrency
-      await channel.prefetch(1);
-      
-      // Process individual notifications
+      await channel.prefetch(10);
+
       await channel.consume(config.rabbitmq.queues.notification, async (msg) => {
         if (!msg) return;
 
         try {
           const notificationData = JSON.parse(msg.content.toString());
 
-          // Check if notification already exists in DB (has _id) or needs to be created
           let notification;
           if (notificationData._id) {
             notification = notificationData;
-            logger.debug(`Processing existing notification: ${notification._id}`);
           } else {
-            // Create notification in database (from feed-service or message-svc)
             notification = await Notification.create({
               userId: notificationData.userId,
               type: notificationData.type || 'in_app',
@@ -34,46 +31,51 @@ class BatchProcessor {
               data: notificationData.data,
               category: notificationData.category || 'system',
               priority: notificationData.priority || 'medium',
-              status: 'pending',
+              status: NOTIFICATION_STATUS.PENDING,
               scheduledFor: new Date(),
             });
-            logger.debug(`Created new notification: ${notification._id} from ${notificationData.source || 'unknown'}`);
           }
 
           await processor.processNotification(notification);
-
-          // Acknowledge message
           channel.ack(msg);
         } catch (error) {
           logger.error('Error processing notification from queue:', error);
-          // Negative acknowledge to requeue
           channel.nack(msg, false, true);
         }
       });
-      
-      // Process batches
+
       await channel.consume(config.rabbitmq.queues.batch, async (msg) => {
         if (!msg) return;
-        
+
         try {
           const batch = JSON.parse(msg.content.toString());
           logger.info(`Processing batch: ${batch.batchId} with ${batch.count} notifications`);
-          
-          // Process each notification in the batch
+
           for (const notification of batch.notifications) {
             await processor.processNotification(notification);
           }
-          
-          // Acknowledge message
+
           channel.ack(msg);
         } catch (error) {
           logger.error('Error processing batch from queue:', error);
-          // Negative acknowledge to requeue
           channel.nack(msg, false, true);
         }
       });
-      
-      logger.info('Batch processor started and consuming from queues');
+
+      await channel.consume(config.rabbitmq.queues.event, async (msg) => {
+        if (!msg) return;
+
+        try {
+          const eventPayload = JSON.parse(msg.content.toString());
+          await eventNotificationService.handleEvent(eventPayload);
+          channel.ack(msg);
+        } catch (error) {
+          logger.error('Error processing event from queue:', error);
+          channel.nack(msg, false, false);
+        }
+      });
+
+      logger.info('Batch processor started and consuming notification, batch and event queues');
     } catch (error) {
       logger.error('Failed to start batch processor:', error);
       throw error;
@@ -82,21 +84,28 @@ class BatchProcessor {
 
   async scheduleBatchProcessing() {
     const batchInterval = config.batch.intervalMs;
-    
-    // Run batch processing on a schedule
+
     setInterval(async () => {
       try {
         logger.debug('Starting scheduled batch processing');
-        
-        // Find pending notifications and process them in batches
         const pendingCount = await this._processPendingNotifications();
-        
         logger.info(`Scheduled batch processing completed. Processed ${pendingCount} notifications.`);
       } catch (error) {
         logger.error('Error in scheduled batch processing:', error);
       }
     }, batchInterval);
-    
+
+    setInterval(async () => {
+      try {
+        const flushed = await digestService.flushDigests();
+        if (flushed) {
+          logger.info(`Digest flush completed. Generated ${flushed} digest notifications.`);
+        }
+      } catch (error) {
+        logger.error('Error during digest flush:', error);
+      }
+    }, config.batch.digestFlushIntervalMs || 300000);
+
     logger.info(`Scheduled batch processing every ${batchInterval}ms`);
   }
 
@@ -104,41 +113,33 @@ class BatchProcessor {
     try {
       const now = new Date();
       const batchSize = config.batch.size;
-      
-      // Find notifications ready to send
+
       const pendingNotifications = await Notification.find({
-        status: 'pending',
-        scheduledFor: { $lte: now }
+        status: { $in: [NOTIFICATION_STATUS.PENDING, NOTIFICATION_STATUS.DEFERRED] },
+        scheduledFor: { $lte: now },
       }).limit(batchSize);
-      
+
       if (pendingNotifications.length === 0) {
         logger.debug('No pending notifications found for batch processing');
         return 0;
       }
-      
-      // Group notifications by user to avoid overwhelming users
+
       const groupedByUser = this._groupByUser(pendingNotifications);
-      
       let processedCount = 0;
-      
-      // Process each user's batch
+
       for (const [userId, notifications] of Object.entries(groupedByUser)) {
-        // Create a batch ID
         const batchId = `batch-${Date.now()}-${userId}`;
-        
-        // Update notifications with batch ID
-        const notificationIds = notifications.map(n => n._id);
+        const notificationIds = notifications.map((n) => n._id);
+
         await Notification.updateMany(
           { _id: { $in: notificationIds } },
-          { batchId, status: 'processing' }
+          { batchId, status: NOTIFICATION_STATUS.PROCESSING }
         );
-        
-        // Send to batch queue
+
         await this._sendToBatchQueue(notifications, batchId);
-        
         processedCount += notifications.length;
       }
-      
+
       return processedCount;
     } catch (error) {
       logger.error('Error processing pending notifications:', error);
@@ -148,33 +149,33 @@ class BatchProcessor {
 
   _groupByUser(notifications) {
     const grouped = {};
-    
+
     for (const notification of notifications) {
       if (!grouped[notification.userId]) {
         grouped[notification.userId] = [];
       }
       grouped[notification.userId].push(notification);
     }
-    
+
     return grouped;
   }
 
   async _sendToBatchQueue(notifications, batchId) {
     try {
       const channel = rabbitmq.getChannel();
-      
+
       const message = JSON.stringify({
         batchId,
         count: notifications.length,
-        notifications
+        notifications,
       });
-      
+
       await channel.sendToQueue(
         config.rabbitmq.queues.batch,
         Buffer.from(message),
         { persistent: true }
       );
-      
+
       logger.debug(`Sent batch ${batchId} with ${notifications.length} notifications to queue`);
       return true;
     } catch (error) {
@@ -184,4 +185,4 @@ class BatchProcessor {
   }
 }
 
-module.exports = new BatchProcessor(); 
+module.exports = new BatchProcessor();

--- a/Backend-JS/notification-service/src/workers/processor.js
+++ b/Backend-JS/notification-service/src/workers/processor.js
@@ -5,125 +5,120 @@ const pushService = require('../services/push.service');
 const websocketService = require('../services/websocket.service');
 const redisClient = require('../config/redis');
 const logger = require('../utils/logger');
+const { NOTIFICATION_STATUS } = require('../utils/constants');
 
-// Simple email transporter - replace with your SMTP settings
 const emailTransporter = nodemailer.createTransport({
   host: process.env.SMTP_HOST || 'smtp.example.com',
-  port: parseInt(process.env.SMTP_PORT || '587'),
+  port: parseInt(process.env.SMTP_PORT || '587', 10),
   secure: process.env.SMTP_SECURE === 'true',
   auth: {
     user: process.env.SMTP_USER || 'user@example.com',
-    pass: process.env.SMTP_PASS || 'password'
-  }
+    pass: process.env.SMTP_PASS || 'password',
+  },
 });
 
 class NotificationProcessor {
   async processNotification(notification) {
     try {
-      // Check if this is a valid notification
       if (!notification || !notification.userId) {
         logger.error('Invalid notification received:', notification);
         return false;
       }
-      
-      // Get user preferences
+
       const preferences = await this._getUserPreferences(notification.userId);
-      
-      // Skip if notifications are disabled globally for this user
+
       if (!preferences.enabled) {
-        await this._updateNotificationStatus(notification._id, 'skipped', 'Notifications disabled by user');
+        await this._updateNotificationStatus(notification._id, NOTIFICATION_STATUS.SKIPPED, 'Notifications disabled by user');
         return true;
       }
-      
-      // Skip if this category is disabled
-      if (notification.category && !preferences.categories[notification.category]) {
-        await this._updateNotificationStatus(notification._id, 'skipped', `Category ${notification.category} disabled by user`);
+
+      if (notification.category && preferences.categories?.[notification.category] === false) {
+        await this._updateNotificationStatus(notification._id, NOTIFICATION_STATUS.SKIPPED, `Category ${notification.category} disabled by user`);
         return true;
       }
-      
-      // Skip if in quiet hours
+
       if (this._isInQuietHours(preferences)) {
-        // Reschedule for after quiet hours
         const rescheduleTime = this._getTimeAfterQuietHours(preferences);
         await this._rescheduleNotification(notification._id, rescheduleTime);
+        await this._updateNotificationStatus(notification._id, NOTIFICATION_STATUS.DEFERRED, 'Deferred due to quiet hours');
         return true;
       }
-      
-      // Process based on notification type
-      let result = false;
-      switch (notification.type) {
-        case 'push':
-          result = await this._sendPushNotification(notification, preferences);
+
+      const deliveryOrder = [notification.type, ...(notification.fallbackChannels || [])];
+      const seenChannels = new Set();
+      let deliveredChannel = null;
+
+      for (const channel of deliveryOrder) {
+        if (seenChannels.has(channel)) continue;
+        seenChannels.add(channel);
+
+        const result = await this._sendByChannel(channel, notification, preferences);
+        if (result) {
+          deliveredChannel = channel;
           break;
-        case 'email':
-          result = await this._sendEmailNotification(notification, preferences);
-          break;
-        case 'sms':
-          result = await this._sendSmsNotification(notification, preferences);
-          break;
-        case 'in_app':
-          result = await this._sendInAppNotification(notification);
-          break;
-        default:
-          logger.warn(`Unknown notification type: ${notification.type}`);
-          result = false;
+        }
       }
-      
-      // Update notification status based on result
-      if (result) {
-        await this._updateNotificationStatus(notification._id, 'delivered');
-      } else {
-        await this._updateNotificationStatus(notification._id, 'failed', 'Delivery failed');
+
+      if (deliveredChannel) {
+        await this._markDeliverySuccess(notification._id, deliveredChannel);
+        return true;
       }
-      
-      return result;
+
+      await this._updateNotificationStatus(notification._id, NOTIFICATION_STATUS.FAILED, 'Delivery failed across all channels');
+      return false;
     } catch (error) {
       logger.error('Error processing notification:', error);
-      await this._updateNotificationStatus(notification._id, 'failed', error.message);
+      await this._updateNotificationStatus(notification._id, NOTIFICATION_STATUS.FAILED, error.message);
       return false;
+    }
+  }
+
+  async _sendByChannel(channel, notification, preferences) {
+    switch (channel) {
+      case 'push':
+        return this._sendPushNotification(notification, preferences);
+      case 'email':
+        return this._sendEmailNotification(notification, preferences);
+      case 'sms':
+        return this._sendSmsNotification(notification, preferences);
+      case 'in_app':
+        return this._sendInAppNotification(notification);
+      default:
+        logger.warn(`Unknown notification type: ${channel}`);
+        return false;
     }
   }
 
   async _getUserPreferences(userId) {
     const cacheKey = `user_prefs:${userId}`;
     const cachedPrefs = await redisClient.get(cacheKey);
-    
+
     if (cachedPrefs) {
       return JSON.parse(cachedPrefs);
     }
-    
+
     let preferences = await UserNotificationPreferences.findOne({ userId });
-    
+
     if (!preferences) {
       preferences = await UserNotificationPreferences.create({ userId });
     }
-    
+
     await redisClient.set(cacheKey, JSON.stringify(preferences), 'EX', 3600);
-    
     return preferences;
   }
 
   async _sendPushNotification(notification, preferences) {
-    if (!preferences.channels.push.enabled || !preferences.channels.push.token) {
-      logger.debug(`Push notifications disabled for user ${notification.userId}`);
+    if (!preferences.channels?.push?.enabled || !preferences.channels?.push?.token) {
       return false;
     }
-    
+
     try {
-      // Prepare recipient data
       const recipient = {
         userId: notification.userId,
-        token: preferences.channels.push.token
+        token: preferences.channels.push.token,
       };
-      
-      // Use the custom push service
-      const result = await pushService.sendPush(notification, recipient);
-      
-      if (result) {
-        logger.debug(`Successfully sent push notification to user ${notification.userId}`);
-      }
-      
-      return result;
+
+      return await pushService.sendPush(notification, recipient);
     } catch (error) {
       logger.error('Error sending push notification:', error);
       return false;
@@ -131,27 +126,18 @@ class NotificationProcessor {
   }
 
   async _sendEmailNotification(notification, preferences) {
-    if (!preferences.channels.email.enabled || !preferences.channels.email.address) {
-      logger.debug(`Email notifications disabled for user ${notification.userId}`);
+    if (!preferences.channels?.email?.enabled || !preferences.channels?.email?.address) {
       return false;
     }
-    
+
     try {
       const info = await emailTransporter.sendMail({
         from: '"Farming App" <notifications@farmingapp.com>',
         to: preferences.channels.email.address,
         subject: notification.title,
         text: notification.body,
-        html: `<div style="font-family: Arial, sans-serif; max-width: 600px;">
-                <h2>${notification.title}</h2>
-                <p>${notification.body}</p>
-                ${notification.data.actionUrl ? 
-                  `<p><a href="${notification.data.actionUrl}" style="background-color: #4CAF50; color: white; padding: 10px 15px; text-decoration: none; border-radius: 4px;">View Details</a></p>` : 
-                  ''}
-                <p style="color: #666; font-size: 12px;">You received this email because you're subscribed to ${notification.category} notifications.</p>
-              </div>`
       });
-      
+
       logger.debug(`Email sent: ${info.messageId}`);
       return true;
     } catch (error) {
@@ -161,20 +147,16 @@ class NotificationProcessor {
   }
 
   async _sendSmsNotification(notification, preferences) {
-    if (!preferences.channels.sms.enabled || !preferences.channels.sms.phoneNumber) {
-      logger.debug(`SMS notifications disabled for user ${notification.userId}`);
+    if (!preferences.channels?.sms?.enabled || !preferences.channels?.sms?.phoneNumber) {
       return false;
     }
-    
-    // This is a placeholder. In a real application, you would integrate with an SMS provider
-    // like Twilio, Nexmo, AWS SNS, etc.
+
     logger.debug(`Would send SMS to ${preferences.channels.sms.phoneNumber}: ${notification.title} - ${notification.body}`);
     return true;
   }
 
   async _sendInAppNotification(notification) {
-    // Send via WebSocket if user is connected
-    const sent = websocketService.sendNotification(notification.userId, {
+    websocketService.sendNotification(notification.userId, {
       _id: notification._id,
       type: notification.type,
       title: notification.title,
@@ -185,13 +167,16 @@ class NotificationProcessor {
       createdAt: notification.createdAt,
     });
 
-    if (sent) {
-      logger.debug(`In-app notification sent via WebSocket to user ${notification.userId}`);
-    } else {
-      logger.debug(`In-app notification ready for user ${notification.userId} (not connected via WebSocket)`);
-    }
-
     return true;
+  }
+
+  async _markDeliverySuccess(notificationId, channel) {
+    await Notification.findByIdAndUpdate(notificationId, {
+      status: NOTIFICATION_STATUS.DELIVERED,
+      deliveredAt: new Date(),
+      $push: { channelTrail: channel },
+      updatedAt: new Date(),
+    });
   }
 
   async _updateNotificationStatus(notificationId, status, message = null) {
@@ -199,7 +184,7 @@ class NotificationProcessor {
       await Notification.findByIdAndUpdate(notificationId, {
         status,
         ...(message ? { 'data.statusMessage': message } : {}),
-        updatedAt: new Date()
+        updatedAt: new Date(),
       });
       return true;
     } catch (error) {
@@ -212,7 +197,7 @@ class NotificationProcessor {
     try {
       await Notification.findByIdAndUpdate(notificationId, {
         scheduledFor,
-        updatedAt: new Date()
+        updatedAt: new Date(),
       });
       return true;
     } catch (error) {
@@ -222,42 +207,37 @@ class NotificationProcessor {
   }
 
   _isInQuietHours(preferences) {
-    if (!preferences.quietHours.enabled) return false;
-    
+    if (!preferences.quietHours?.enabled) return false;
+
     const now = new Date();
-    const currentHour = now.getHours();
-    const currentMinute = now.getMinutes();
-    
+    const currentTime = now.getHours() * 60 + now.getMinutes();
+
     const [startHour, startMinute] = preferences.quietHours.start.split(':').map(Number);
     const [endHour, endMinute] = preferences.quietHours.end.split(':').map(Number);
-    
-    const currentTime = currentHour * 60 + currentMinute;
+
     const startTime = startHour * 60 + startMinute;
     const endTime = endHour * 60 + endMinute;
-    
-    // Handle case where quiet hours cross midnight
+
     if (startTime > endTime) {
       return currentTime >= startTime || currentTime <= endTime;
-    } else {
-      return currentTime >= startTime && currentTime <= endTime;
     }
+
+    return currentTime >= startTime && currentTime <= endTime;
   }
 
   _getTimeAfterQuietHours(preferences) {
     const [endHour, endMinute] = preferences.quietHours.end.split(':').map(Number);
-    
+
     const now = new Date();
     const afterQuietHours = new Date(now);
-    
     afterQuietHours.setHours(endHour, endMinute, 0, 0);
-    
-    // If after quiet hours is earlier than now, add a day
+
     if (afterQuietHours < now) {
       afterQuietHours.setDate(afterQuietHours.getDate() + 1);
     }
-    
+
     return afterQuietHours;
   }
 }
 
-module.exports = new NotificationProcessor(); 
+module.exports = new NotificationProcessor();


### PR DESCRIPTION
### Motivation
- Reduce noisy or duplicate notifications by adding dedupe, rate-limits and mute rules before delivery. 
- Support user-configurable delivery modes (instant vs digest) and channel fallback so important messages are delivered while low-priority noise is digested. 
- Collect richer interaction/analytics metadata and expose preference APIs so downstream services can adapt and users can control sources.

### Description
- Added a policy engine that implements deduplication, category frequency caps and mute checks in `src/services/notification-policy.service.js`. 
- Implemented digest support with per-user/category enqueue and scheduled flush that emits summary notifications in `src/services/digest.service.js` and scheduled in `src/workers/batch-processor.js`. 
- Centralized event -> notification templates and interest matching in `src/services/event-template.service.js`, and wired robust domain-event handling (recipient resolution, filtering, delivery-mode routing) in `src/services/event-notification.service.js`. 
- Added channel fallback and delivery-trail tracking in the processor (`src/workers/processor.js`), expanded notification model for analytics (`src/models/notification.model.js`), and extended user preference schema with delivery modes, muted sources and frequency caps (`src/models/user.model.js`). 
- Queue and RabbitMQ plumbing updated to assert event queue/exchange and to publish/consume events (`src/config/rabbitmq.js`, `src/services/queue.service.js`, `src/config/index.js`). 
- Exposed new APIs for event ingestion, mute/unmute, interaction tracking and test notifications via controller and routes (`src/api/controllers/notification.controller.js`, `src/api/routes.js`). 
- Added unit tests for policy behavior and template generation (`src/services/__tests__/notification-policy.service.test.js`, `src/services/__tests__/event-template.service.test.js`) and updated constants (`src/utils/constants.js`) and `.env.example` to support digest/event settings. 

### Testing
- Ran unit tests in the notification service with `npm test -- --runInBand` (run in `Backend-JS/notification-service`) and the suite passed: 2 test suites, 5 tests passed. 
- Performed basic syntax checks using `node -c` on updated service/worker files to ensure no parse errors, which completed without errors. 
- Added mocks in tests for Redis interactions to validate dedupe and mute logic (tests succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990bfd6d918832a956b413b47a18bbd)